### PR TITLE
Update List.js

### DIFF
--- a/src/components/List/List.js
+++ b/src/components/List/List.js
@@ -9,7 +9,7 @@ const List = ({ places, type, setType, rating, setRating, childClicked, isLoadin
   const classes = useStyles();
 
   useEffect(() => {
-    setElRefs((refs) => Array(places.length).fill().map((_, i) => refs[i] || createRef()));
+    setElRefs((refs) => places.map((_, i) => refs[i] || createRef()));
   }, [places]);
 
   return (


### PR DESCRIPTION
Array.fill() should have at list one argument, and right it hasn't, in this case it's not make sens to write Array(places.length).fill().map(), why not make it simpler places.map()